### PR TITLE
Implement AddOdometerReading AppIntent

### DIFF
--- a/Basic-Car-Maintenance.xcodeproj/project.pbxproj
+++ b/Basic-Car-Maintenance.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		8A3D74862AD6D9A10000FEEB /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3D74852AD6D9A10000FEEB /* AlertView.swift */; };
 		8A3D748A2AD9C3E00000FEEB /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3D74892AD9C3E00000FEEB /* MainTabViewModel.swift */; };
 		8A3D748C2AD9C41D0000FEEB /* AlertItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3D748B2AD9C41D0000FEEB /* AlertItem.swift */; };
+		8AD8735D2C788BD800C89945 /* AddOdometerReadingAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD8735C2C788BD800C89945 /* AddOdometerReadingAppIntent.swift */; };
 		8AEE816F2ACF37F800FC0C2A /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE816E2ACF37F800FC0C2A /* Action.swift */; };
 		8AEE81722ACF384D00FC0C2A /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE81712ACF384D00FC0C2A /* MainTabView.swift */; };
 		E4345E622B4CDA7B0086D04B /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4345E612B4CDA7B0086D04B /* WelcomeView.swift */; };
@@ -122,6 +123,7 @@
 		8A3D74852AD6D9A10000FEEB /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		8A3D74892AD9C3E00000FEEB /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		8A3D748B2AD9C41D0000FEEB /* AlertItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertItem.swift; sourceTree = "<group>"; };
+		8AD8735C2C788BD800C89945 /* AddOdometerReadingAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOdometerReadingAppIntent.swift; sourceTree = "<group>"; };
 		8AEE816E2ACF37F800FC0C2A /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		8AEE81712ACF384D00FC0C2A /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		8AEE81732ACF394E00FC0C2A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -285,6 +287,14 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		8AD8735B2C788BC500C89945 /* AppIntents */ = {
+			isa = PBXGroup;
+			children = (
+				8AD8735C2C788BD800C89945 /* AddOdometerReadingAppIntent.swift */,
+			);
+			path = AppIntents;
+			sourceTree = "<group>";
+		};
 		E4345E602B4CDA4F0086D04B /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -407,6 +417,7 @@
 				FFC8CDA32AA385E800D129A6 /* GoogleService-Info.plist */,
 				8AEE81732ACF394E00FC0C2A /* Info.plist */,
 				FF5D13A62A86C2D600BC9BD6 /* BasicCarMaintenanceApp.swift */,
+				8AD8735B2C788BC500C89945 /* AppIntents */,
 				E4345E602B4CDA4F0086D04B /* Onboarding */,
 				8A3D74832AD6D9870000FEEB /* MainView */,
 				FFBFE08F2A98EFDD000A9BEB /* Models */,
@@ -757,6 +768,7 @@
 				57CDD9A02ADC31A8002EFED0 /* AddOdometerReadingView.swift in Sources */,
 				57CDD99E2ADC3173002EFED0 /* OdometerViewModel.swift in Sources */,
 				E4345E642B4CE0500086D04B /* WelcomeViewAddVehicle.swift in Sources */,
+				8AD8735D2C788BD800C89945 /* AddOdometerReadingAppIntent.swift in Sources */,
 				E55B630D2B079E5A006BDDDF /* EditVehicleView.swift in Sources */,
 				FF755B3E2A908E7A00F49A13 /* SettingsView.swift in Sources */,
 				FF3DDF522AA4D28F009D91C4 /* DashboardViewModel.swift in Sources */,

--- a/Basic-Car-Maintenance/Shared/AppIntents/AddOdometerReadingAppIntent.swift
+++ b/Basic-Car-Maintenance/Shared/AppIntents/AddOdometerReadingAppIntent.swift
@@ -1,0 +1,90 @@
+//
+//  AddOdometerReadingAppIntent.swift
+//  Basic-Car-Maintenance
+//
+//  Created by Omar Hegazy on 23/08/2024.
+//
+
+import Foundation
+import AppIntents
+
+struct VehicleQuery: EntityQuery {
+   
+    func entities(for identifiers: [Vehicle.ID]) async throws -> [Vehicle] {
+        try await fetchVehicles()
+    }
+    
+    func suggestedEntities() async throws -> [Vehicle] {
+        try await fetchVehicles()
+    }
+    
+    private func fetchVehicles() async throws -> [Vehicle] {
+        let authViewModel = await AuthenticationViewModel()
+        let odometerVM = OdometerViewModel(userUID: authViewModel.user?.uid)
+        await odometerVM.getVehicles()
+        guard !odometerVM.vehicles.isEmpty else {
+            throw OdometerReadingError.emptyVehicles
+        }
+        return odometerVM.vehicles
+    }
+}
+
+enum DistanceUnit: String, AppEnum, CaseIterable {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Distance Type")
+    static var caseDisplayRepresentations: [DistanceUnit: DisplayRepresentation] {
+        [
+            .mile: "Miles",
+            .kilometer: "Kilometers"
+        ]
+    }
+    
+    case mile
+    case kilometer
+}
+
+struct AddOdometerReadingIntent: AppIntent {
+    @Parameter(title: "Distance")
+    var distance: Int
+    
+    @Parameter(title: "Distance Unit")
+    var distanceType: DistanceUnit
+    
+    @Parameter(title: "Vehicle")
+    var vehicle: Vehicle
+    
+    @Parameter(title: "Date")
+    var date: Date
+    
+    static var title: LocalizedStringResource = "Add Odometer Reading"
+    
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        if distance < 1 {
+            throw OdometerReadingError.invalidDistance
+        }
+        
+        let reading = OdometerReading(
+            date: date,
+            distance: distance,
+            isMetric: distanceType == .kilometer,
+            vehicleID: vehicle.id
+        )
+        let authViewModel = await AuthenticationViewModel()
+        let odometerVM = OdometerViewModel(userUID: authViewModel.user?.uid)
+        try odometerVM.addReading(reading)
+        return .result(dialog: "Added reading successfully")
+    }
+}
+
+enum OdometerReadingError: Error, CustomLocalizedStringResourceConvertible {
+    case invalidDistance
+    case emptyVehicles
+    
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case .invalidDistance:
+            "You can not select distance number less than 1 km or mi"
+        case .emptyVehicles:
+            "No vehicles available, please add a vehicle using the app and try again"
+        }
+    }
+}

--- a/Basic-Car-Maintenance/Shared/Localizable.xcstrings
+++ b/Basic-Car-Maintenance/Shared/Localizable.xcstrings
@@ -369,6 +369,9 @@
         }
       }
     },
+    "Add Odometer Reading" : {
+
+    },
     "Add Reading" : {
       "comment" : "Title for form when adding an odometer reading",
       "localizations" : {
@@ -631,6 +634,9 @@
           }
         }
       }
+    },
+    "Added reading successfully" : {
+
     },
     "AddEvent" : {
       "comment" : "Label for adding maintenance event on Dashboard view",
@@ -1712,6 +1718,12 @@
           }
         }
       }
+    },
+    "Distance Type" : {
+
+    },
+    "Distance Unit" : {
+
     },
     "Edit" : {
       "comment" : "Button label to edit this maintenance",
@@ -3262,6 +3274,9 @@
           }
         }
       }
+    },
+    "No vehicles available, please add a vehicle using the app and try again" : {
+
     },
     "Notes" : {
       "comment" : "Maintenance event notes text field label",
@@ -5856,6 +5871,12 @@
       }
     },
     "You can edit more data about the vehicle in the 'Settings' tab." : {
+
+    },
+    "You can not select a past date" : {
+
+    },
+    "You can not select distance number less than 1 km or mi" : {
 
     },
     "your vehicle" : {

--- a/Basic-Car-Maintenance/Shared/Models/Vehicle.swift
+++ b/Basic-Car-Maintenance/Shared/Models/Vehicle.swift
@@ -7,9 +7,13 @@
 
 import FirebaseFirestoreSwift
 import Foundation
+import AppIntents
 
-struct Vehicle: Codable, Identifiable, Hashable {
-    @DocumentID var id: String?
+struct Vehicle: Codable, Identifiable, Hashable, AppEntity {
+    var id: String {
+        documentID ?? ""
+    }
+    @DocumentID private var documentID: String?
     var userID: String?
     let name: String
     let make: String
@@ -18,17 +22,23 @@ struct Vehicle: Codable, Identifiable, Hashable {
     let color: String?
     let vin: String?
     let licensePlateNumber: String?
+    var displayRepresentation: DisplayRepresentation { DisplayRepresentation(title: "\(name)") }
     
-    init(id: String? = nil,
-         userID: String? = nil,
-         name: String,
-         make: String,
-         model: String,
-         year: String? = nil,
-         color: String? = nil,
-         vin: String? = nil,
-         licensePlateNumber: String? = nil) {
-        self.id = id
+    static var defaultQuery = VehicleQuery()
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Vehicle")
+    
+    init(
+        id: String = "",
+        userID: String? = nil,
+        name: String,
+        make: String,
+        model: String,
+        year: String? = nil,
+        color: String? = nil,
+        vin: String? = nil,
+        licensePlateNumber: String? = nil
+    ) {
+        self.documentID = id
         self.userID = userID
         self.name = name
         self.make = make
@@ -37,5 +47,17 @@ struct Vehicle: Codable, Identifiable, Hashable {
         self.color = color
         self.vin = vin
         self.licensePlateNumber = licensePlateNumber
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case documentID = "_id"
+        case userID
+        case name
+        case make
+        case model
+        case year
+        case color
+        case vin
+        case licensePlateNumber
     }
 }

--- a/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/ViewModels/SettingsViewModel.swift
@@ -82,14 +82,13 @@ final class SettingsViewModel {
     func updateVehicle(_ vehicle: Vehicle) async {
         
         if let userUID = authenticationViewModel.user?.uid {
-            guard let vehicleID = vehicle.id else { return }
             var vehicleToUpdate = vehicle
             vehicleToUpdate.userID = userUID
             
             do {
                 try Firestore.firestore()
                     .collection(FirestoreCollection.vehicles)
-                    .document(vehicleID)
+                    .document(vehicle.id)
                     .setData(from: vehicleToUpdate)
                 
                 AnalyticsService.shared.logEvent(.vehicleUpdate)

--- a/Basic-Car-Maintenance/Shared/Settings/Views/EditVehicleView.swift
+++ b/Basic-Car-Maintenance/Shared/Settings/Views/EditVehicleView.swift
@@ -86,15 +86,16 @@ struct EditVehicleView: View, Observable {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         if let selectedVehicle {
-                            var vehicle = Vehicle(
+                            let vehicle = Vehicle(
+                                id: selectedVehicle.id,
                                 name: name,
                                 make: make,
                                 model: model,
                                 year: year,
                                 color: color,
                                 vin: VIN,
-                                licensePlateNumber: licensePlateNumber)
-                            vehicle.id = selectedVehicle.id
+                                licensePlateNumber: licensePlateNumber
+                            )
                             Task {
                                 await viewModel.updateVehicle(vehicle)
                                 dismiss()


### PR DESCRIPTION
# What it Does
* Closes #222
Implement shortcut for adding new odometer reading

### What is implemented?
1. `Vehicle` now conforms to `AppEntity` protocol, hence, it should have an explicit `id`, which represents `documentId` under the hood
2. `VehicleQuery` is simply fetching vehicles from the server
3. `DistanceUnit` enum is used to make it more readable for selecting Distance unit
4. In `AddOdometerReadingIntent`, validation is applied to `Distance`, and if the vehicles are empty, then the user will not be able to finish the shortcut

# How I Tested
###  Happy Scenario
1. Install the app
2. Make sure at least one vehicle is added in the app by going to `Settings` tab > `Add Vehicle`
3. Switch to Shortcuts app
4. Tab on the `+` on the top right corner
5. Tab on `⨁ Add Action`
6. Select `Apps` tab
7. Tab on `Basic Car`
8. Tab on `Add Odometer Reading`
9. Add data for all fields and tab the play button on the bottom right corner
10. See the result

###  Unhappy Scenario
#### Senario1
1. Install the app
2. Make sure at least one vehicle is added in the app by going to `Settings` tab > `Add Vehicle`
3. Switch to Shortcuts app
4. Tab on the `+` on the top right corner
5. Tab on `⨁ Add Action`
6. Select `Apps` tab
7. Tab on `Basic Car`
8. Tab on `Add Odometer Reading`
9. Try to set distance value to zero or negative value
10. See the result (user won't be able to proceed if the distance value is less than 1)

#### Senario2
1. Install the app
2. Make sure **no** vehicles are added
3. Switch to Shortcuts app
4. Tab on the `+` on the top right corner
5. Tab on `⨁ Add Action`
6. Select `Apps` tab
7. Tab on `Basic Car`
8. Tab on `Add Odometer Reading`
9. Try to set distance value to zero or negative value
10. See the result (user won't be able to proceed because there are no vehicles)


